### PR TITLE
remove usage of middle layer CMSIS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Debug/
+.vscode/

--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -28,6 +28,12 @@ extern "C" {
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h5xx_hal.h"
+#include "FreeRTOS.h"
+#include "task.h"
+#include "timers.h"
+#include "queue.h"
+#include "semphr.h"
+#include "event_groups.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -18,7 +18,6 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
-#include "cmsis_os2.h"
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -93,13 +92,14 @@ int main(void)
   /* USER CODE END 2 */
 
   /* Init scheduler */
-  osKernelInitialize();
+  //osKernelInitialize();
 
   /* Call init function for freertos objects (in app_freertos.c) */
-  MX_FREERTOS_Init();
+  //MX_FREERTOS_Init();
 
   /* Start scheduler */
-  osKernelStart();
+  //osKernelStart();
+  vTaskStartScheduler(); 
 
   /* We should never get here as control is now taken by the scheduler */
 


### PR DESCRIPTION
Inspired by this guide: https://jaywang.info/using-native-freertos-in-stm32-microcontrollers/

The new version (v2) of cmsis organize things in a different way so the proper changes have been made.